### PR TITLE
Various documentation fixes

### DIFF
--- a/src/docs/Building and Distributing Akka.NET.md
+++ b/src/docs/Building and Distributing Akka.NET.md
@@ -2,9 +2,9 @@
 layout: docs.hbs
 title: Building and Distributing Akka.NET
 ---
-Akka.Net has an official beta [NuGet package](http://www.nuget.org/packages/Akka).
+Akka.Net has an official [NuGet package](http://www.nuget.org/packages/Akka).
 
-To install Akka.net, run the following command in the Package Manager Console:
+To install Akka.NET, run the following command in the Package Manager Console:
 ````
    PM> Install-Package Akka -Pre
 ````
@@ -13,7 +13,8 @@ You can also build it locally from the source code.
 
 ## Building Akka.NET with Fake
 
-The build as been ported to [Fake](http://fsharp.github.io/FAKE/) to make it even easier to compile.
+The build as been ported to [Fake](http://fsharp.github.io/FAKE/) to make it
+even easier to compile.
 
 Clone the source code from GitHub (currently only on the dev branch):
 
@@ -38,7 +39,9 @@ The ```all``` targets runs the following targets in order:
 
 ### Version management
 
-The build uses the last version number specified in the [RELEASE_NOTES.md](https://github.com/akkadotnet/akka.net/blob/dev/RELEASE_NOTES.md) file.
+The build uses the last version number specified in the
+[RELEASE_NOTES.md](https://github.com/akkadotnet/akka.net/blob/dev/RELEASE_NOTES.md)
+file.
 
 The release notes are also used in nuget packages.
 

--- a/src/docs/CircuitBreaker.md
+++ b/src/docs/CircuitBreaker.md
@@ -5,26 +5,30 @@ title: CircuitBreaker
 #Circuit Breaker
 
 ##Why are they used?
-A circuit breaker is used to provide stability and prevent cascading failures in distributed
-systems.  These should be used in conjunction with judicious timeouts at the interfaces between
-remote systems to prevent the failure of a single component from bringing down all components.
+A circuit breaker is used to provide stability and prevent cascading failures
+in distributed systems. These should be used in conjunction with judicious
+timeouts at the interfaces between remote systems to prevent the failure of a
+single component from bringing down all components.
 
-As an example, we have a web application interacting with a remote third party web service.
-Let's say the third party has oversold their capacity and their database melts down under load.
-Assume that the database fails in such a way that it takes a very long time to hand back an
-error to the third party web service.  This in turn makes calls fail after a long period of
-time.  Back to our web application, the users have noticed that their form submissions take
-much longer seeming to hang.  Well the users do what they know to do which is use the refresh
-button, adding more requests to their already running requests.  This eventually causes the
-failure of the web application due to resource exhaustion.  This will affect all users, even
-those who are not using functionality dependent on this third party web service.
+As an example, we have a web application interacting with a remote third party
+web service. Let's say the third party has oversold their capacity and their
+database melts down under load. Assume that the database fails in such a way
+that it takes a very long time to hand back an error to the third party web
+service. This in turn makes calls fail after a long period of time. Back to our
+web application, the users have noticed that their form submissions take much
+longer seeming to hang. Well the users do what they know to do which is use the
+refresh button, adding more requests to their already running requests. This
+eventually causes the failure of the web application due to resource exhaustion.
+This will affect all users, even those who are not using functionality dependent
+on this third party web service.
 
-Introducing circuit breakers on the web service call would cause the requests to begin to
-fail-fast, letting the user know that something is wrong and that they need not refresh
-their request.  This also confines the failure behavior to only those users that are using
-functionality dependent on the third party, other users are no longer affected as there is no
-resource exhaustion.  Circuit breakers can also allow savvy developers to mark portions of
-the site that use the functionality unavailable, or perhaps show some cached content as
+Introducing circuit breakers on the web service call would cause the requests to
+begin to fail-fast, letting the user know that something is wrong and that they
+need not refresh their request. This also confines the failure behavior to only
+those users that are using functionality dependent on the third party, other
+users are no longer affected as there is no resource exhaustion. Circuit
+breakers can also allow savvy developers to mark portions of the site that use
+the functionality unavailable, or perhaps show some cached content as
 appropriate while the breaker is open.
 
 The Akka library provides an implementation of a circuit breaker called
@@ -33,22 +37,27 @@ The Akka library provides an implementation of a circuit breaker called
 ##What do they do?
 
 * During normal operation, a circuit breaker is in the `Closed` state:
-	* Exceptions or calls exceeding the configured `callTimeout` increment a failure counter
+	* Exceptions or calls exceeding the configured `callTimeout` increment a
+	  failure counter
 	* Successes reset the failure count to zero
-	* When the failure counter reaches a `maxFailures` count, the breaker is tripped into `Open` state
+	* When the failure counter reaches a `maxFailures` count, the breaker is
+	  tripped into `Open` state
 * While in `Open` state:
 	* All calls fail-fast with a :class:`CircuitBreakerOpenException`
-	* After the configured `resetTimeout`, the circuit breaker enters a `Half-Open` state
+	* After the configured `resetTimeout`, the circuit breaker enters a
+	  `Half-Open` state
 * In `Half-Open` state:
 	* The first call attempted is allowed through without failing fast
 	* All other calls fail-fast with an exception just as in `Open` state
 	* If the first call succeeds, the breaker is reset back to `Closed` state
-	* If the first call fails, the breaker is tripped again into the `Open` state for another full `resetTimeout`
+	* If the first call fails, the breaker is tripped again into the `Open` state
+	  for another full `resetTimeout`
 * State transition listeners:
-	* Callbacks can be provided for every state entry via `onOpen`, `onClose`, and `onHalfOpen`
+	* Callbacks can be provided for every state entry via `onOpen`, `onClose`,
+	  and `onHalfOpen`
 	* These are executed in the :class:`ExecutionContext` provided.
 
-.. image:: ../images/circuit-breaker-states.png
+![Circuit breaker states](images/circuit-breaker-states.png)
 
 ##Examples
 
@@ -86,6 +95,6 @@ call as well as a synchronous one:
 
 >**Note**<br/>
 Using the :class:`CircuitBreaker` companion object's `apply` or `create` methods
-will return a :class:`CircuitBreaker` where callbacks are executed in the caller's thread.
-This can be useful if the asynchronous :class:`Future` behavior is unnecessary, for
-example invoking a synchronous-only API.
+will return a :class:`CircuitBreaker` where callbacks are executed in the
+caller's thread. This can be useful if the asynchronous :class:`Future` behavior
+is unnecessary, for example invoking a synchronous-only API.

--- a/src/docs/Contributor guidelines.md
+++ b/src/docs/Contributor guidelines.md
@@ -35,4 +35,6 @@ e.g.
 the parent should no longer supervise it")]
 public void ClearChildUponTerminated()
 {
+  ...
+}
 ```

--- a/src/docs/DI Core.md
+++ b/src/docs/DI Core.md
@@ -5,93 +5,94 @@ title: DI Core
 
 #Akka.DI.Core
 
-**Actor Producer Extension** library used to create Dependency Injection Container for the [Akka.NET](https://github.com/akkadotnet/akka.net) framework.
+**Actor Producer Extension** library used to create Dependency Injection
+Container for the [Akka.NET](https://github.com/akkadotnet/akka.net) framework.
 
 #What is it?
 
-**Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET framework that provides a simple way to create an Actor Dependency Resolver that can be used an alternative to the basic capabilities of [Props](Props) when you have Actors with multiple dependencies.
+**Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET
+framework that provides a simple way to create an Actor Dependency Resolver
+that can be used an alternative to the basic capabilities of [Props](Props)
+when you have actors with multiple dependencies.
 
 #How do you create an Extension?
 
 -  Create a new class library
--  Reference your favorite IOC Container, the Akka.DI.Core and of course Akka
--  Create a class and implement the IDependencyResolver
+-  Reference your favorite IoC Container, the Akka.DI.Core and of course Akka
+-  Create a class and implement the `IDependencyResolver`
 
-Let's walk through the process of creating one for CastleWindsor container. You need to create  a new project named Akka.DI.CastleWindsor with all the necessary references including Akka.DI.Core, Akka and CastleWindosor. Name the initial class WindsorDependencyResolver.
+Let's walk through the process of creating one for the CastleWindsor container.
+You need to create  a new project named Akka.DI.CastleWindsor with all the
+necessary references including Akka.DI.Core, Akka and CastleWindosor.
+Name the initial class `WindsorDependencyResolver`.
 
 ```csharp
 public class WindsorDependencyResolver : IDependencyResolver
 {
-	Type GetType(string ActorName)
-	{
-	    throw new NotImplementedException();
-	}
-
-	Func<ActorBase> CreateActorFactory(string ActorName)
-	{
-	    throw new NotImplementedException();
-	}
-
-	Props Create<TActor>()
-	{
-	    throw new NotImplementedException();
-	}
+    // we'll implement IDependencyResolver in the following steps
 }
 ```
 
 Add a constructor and private fields.
 
 ```csharp
-private IWindsorContainer container;
-private ActorSystem system;
+private IWindsorContainer _container;
+private ConcurrentDictionary<string, Type> _typeCache;
+private ActorSystem _system;
 
 public WindsorDependencyResolver(IWindsorContainer container, ActorSystem system)
 {
     if (system == null) throw new ArgumentNullException("system");
     if (container == null) throw new ArgumentNullException("container");
-    this.container = container;
-    this.system = system;
-    this.system.AddDependencyResolver(this);
+    _container = container;
+    _typeCache = new ConcurrentDictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);
+    _system = system;
+    _system.AddDependencyResolver(this);
 }
 ```
 
 You have defined three private fields
 
-- IWindsorContainer container
-	- Reference to the container
-- ActorSystem system
-	- Reference to the ActorSystem
+- ```IWindsorContainer _container``` is a reference to the CastleWindsor
+ 	container.
+- ```ConcurrentDictionary<string, Type> _typeCache``` is a thread safe map that
+ 	contains actor name/type associations.
+- ```ActorSystem _system``` is a reference to the ActorSystem.
 
-First you need to implement GetType. This is a basic implementation and is just from demonstration purposes. Essentially this is used by the Extension to get the Type of the Actor from it's type name.
+First you need to implement ```GetType```. This is a basic implementation and
+is just for demonstration purposes. Essentially this is used by the extension
+to get the type of the actor from it's type name.
 
 ```csharp
-Type GetType(string actorName)
+public Type GetType(string actorName)
 {
-    var firstTry = Type.GetType(actorName);
-    Func<Type> searchForType = () =>
-    {
-        return
-        AppDomain.
-            CurrentDomain.
-            GetAssemblies().
-            SelectMany(x => x.GetTypes()).
-            Where(t => t.Name.Equals(actorName)).
-            FirstOrDefault();
-    };
-    return firstTry ?? searchForType();
+    _typeCache.
+        TryAdd(actorName,
+            actorName.GetTypeValue() ??
+            _container.Kernel
+            .GetAssignableHandlers(typeof(object))
+            .Where(handler => handler.ComponentModel.Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase))
+            .Select(handler => handler.ComponentModel.Implementation)
+            .FirstOrDefault());
+
+     return _typeCache[actorName];
 }
 ```
 
-Secondly you need to implement the CreateActorFactory method which will be used by the extension to create the Actor. This implementation will depend upon the API of the container.
+Secondly you need to implement the ```CreateActorFactory``` method which will be
+used by the extension to create the actor. This implementation will depend upon
+the API of the container.
 
 ```csharp
-public Func<ActorBase> CreateActorFactory(string actorName)
+public Func<ActorBase> CreateActorFactory(Type actorType)
 {
-    return () => (ActorBase)container.Resolve(GetType(actorName));
+    return () => (ActorBase)container.Resolve(actorType);
 }
 ```
 
-Lastly, you implement the Create<TActor> which is used register the Props configuration for the referenced Actor Type with the ActorSystem. This method will always be the same implementation.
+Thirdly, you implement the ```Create<TActor>``` which is used register the
+`Props` configuration for the referenced actor type with the `ActorSystem`.
+This method will always be the same implementation.
 
 ```csharp
 public Props Create<TActor>() where TActor : ActorBase
@@ -100,29 +101,105 @@ public Props Create<TActor>() where TActor : ActorBase
 }
 ```
 
-So with that you can do something like the following code example:
+Lastly, you implement the Release method which in this instance is very simple.
+This method is used to remove the actor from the underlying container.
 
 ```csharp
+public void Release(ActorBase actor)
+{
+    this.container.Release(actor);
+}
+```
+
+**Note: For further details on the importance of the release method please read
+the following blog [post](http://blog.ploeh.dk/2014/05/19/di-friendly-framework/).**
+
+The resulting class should look similar to the following:
+
+```csharp
+public class WindsorDependencyResolver : IDependencyResolver
+{
+    private IWindsorContainer container;
+    private ConcurrentDictionary<string, Type> typeCache;
+    private ActorSystem system;
+
+    public WindsorDependencyResolver(IWindsorContainer container, ActorSystem system)
+    {
+        if (system == null) throw new ArgumentNullException("system");
+        if (container == null) throw new ArgumentNullException("container");
+        this.container = container;
+        typeCache = new ConcurrentDictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);
+        this.system = system;
+        this.system.AddDependencyResolver(this);
+    }
+
+    public Type GetType(string actorName)
+    {
+        typeCache.TryAdd(actorName, actorName.GetTypeValue() ??
+            container.Kernel
+              .GetAssignableHandlers(typeof(object))
+              .Where(handler => handler.ComponentModel.Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase))
+              .Select(handler => handler.ComponentModel.Implementation)
+              .FirstOrDefault());
+
+        return typeCache[actorName];
+    }
+
+    public Func<ActorBase> CreateActorFactory(Type actorType)
+    {
+        return () => (ActorBase)container.Resolve(actorType);
+    }
+
+    public Props Create<TActor>() where TActor : ActorBase
+    {
+        return system.GetExtension<DIExt>().Props(typeof(TActor));
+    }
+
+    public void Release(ActorBase actor)
+    {
+        this.container.Release(actor);
+    }
+}
+```
+
+Now, with the preceding class, you can do something like the following example:
+
+```csharp
+// Setup CastleWindsor
 IWindsorContainer container = new WindsorContainer();
 container.Register(Component.For<IWorkerService>().ImplementedBy<WorkerService>());
 container.Register(Component.For<TypedWorker>().Named("TypedWorker").LifestyleTransient());
 
-//Create ActorSystem
+// Create the ActorSystem
 using (var system = ActorSystem.Create("MySystem"))
 {
-   //Create the dependency resolver
-   IDependencyResolver propsResolver =
-		new WindsorDependencyResolver(container,system);
+    // Create the dependency resolver
+    IDependencyResolver resolver = new WindsorDependencyResolver(container, system);
 
-		system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker1");
-		system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker2");
+    // Register the actors with the system
+    system.ActorOf(resolver.Create<TypedWorker>(), "Worker1");
+    system.ActorOf(resolver.Create<TypedWorker>(), "Worker2");
 
-    var hashGroup =
-        system.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(config)));
+    // Create the router
+    IActorRef router = system.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(config)));
 
-    TypedActorMessage msg =
-       new TypedActorMessage { Id = 1,
-                               Name = Guid.NewGuid().ToString() };
-     hashGroup.Tell(msg);
+    // Create the message to send
+    TypedActorMessage message = new TypedActorMessage
+    {
+       Id = 1,
+       Name = Guid.NewGuid().ToString()
+    };
+
+    // Send the message to the router
+    router.Tell(message);
 }
+```
+
+## Creating Child Actors using DI ##
+When you want to create child actors from within your existing actors using
+Dependency Injection you can use the Actor Content extension just like in
+the following example.
+
+```csharp
+Context.DI().ActorOf<TypedActor>().Tell(message);
 ```

--- a/src/docs/Dependency injection.md
+++ b/src/docs/Dependency injection.md
@@ -3,9 +3,13 @@ layout: docs.hbs
 title: Dependency injection
 ---
 # Dependency Injection
-If your Actor has a constructor that takes parameters then those need to be part of the Props as well. But there are cases when a factory method must be used, for example when the actual constructor arguments are determined by a dependency injection framework.
+If your actor has a constructor that takes parameters then those need
+to be part of the `Props` as well, as described above. But there are cases when
+a factory method must be used, for example when the actual constructor arguments
+are determined by a dependency injection framework.
 
-The basic functionality is provided by a `DependencyResolver` class, that can create `Props` using the DI container.
+The basic functionality is provided by a `DependencyResolver` class,
+that can create `Props` using the DI container.
 
 ```csharp
 // Create your DI container of preference
@@ -23,22 +27,12 @@ system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker2");
 
 ```
 
-Creating child Actors from inside an Actor can be done using the DI() extension method.
-
-```csharp
-//In for example the PreStart...
-protected override void PreStart()
-{
-	myWorker = Context.DI().ActorOf<TypedWorker>("childWorker");
-}
-
-```
-
-Currenty, the following Akka.NET Dependency Injection plugins are available:
+Currently the following Akka.NET Dependency Injection plugins are available:
 
 ## AutoFac
 
-In order to use this plugin, install the Nuget package with `Install-Package Akka.DI.AutoFac`, then follow the instructions:
+In order to use this plugin, install the Nuget package with
+`Install-Package Akka.DI.AutoFac`, then follow the instructions:
 
 ```csharp
 // Create and build your container
@@ -54,7 +48,8 @@ var propsResolver = new AutoFacDependencyResolver(container, system);
 
 ## CastleWindsor
 
-In order to use this plugin, install the Nuget package with `Install-Package Akka.DI.CastleWindsor`, then follow the instructions:
+In order to use this plugin, install the Nuget package with
+`Install-Package Akka.DI.CastleWindsor`, then follow the instructions:
 
 ```csharp
 // Create and build your container
@@ -69,13 +64,14 @@ var propsResolver = new WindsorDependencyResolver(container, system);
 
 ## Ninject
 
-In order to use this plugin, install the Nuget package with `Install-Package Akka.DI.Ninject`, then follow the instructions:
+In order to use this plugin, install the Nuget package with
+`Install-Package Akka.DI.Ninject`, then follow the instructions:
 
 ```csharp
 // Create and build your container
 var container = new Ninject.StandardKernel();
 container.Bind<TypedWorker>().To(typeof(TypedWorker));
-container.Bind<IWorkerService>().To(typeof)WorkerService));
+container.Bind<IWorkerService>()To(typeof)WorkerService));
 
 // Create the ActorSystem and Dependency Resolver
 var system = ActorSystem.Create("MySystem");
@@ -84,15 +80,28 @@ var propsResolver = new NinjectDependencyResolver(container,system);
 
 ## Other frameworks
 
-Support for additional dependency injection frameworks may be added in the future, but you can easily implement your own by implementing an [Actor Producer Extension](DI Core).
+Support for additional dependency injection frameworks may be added in the
+future, but you can easily implement your own by implementing an
+[Actor Producer Extension](DI Core).
 
-> **Warning** You might be tempted at times to use an `IndirectActorProducer` which always returns the same instance, e.g. by using a static field. This is not supported, as it goes against the meaning of an actor restart, which is described here: [What Restarting Means](Supervision#what-restarting-means).
+> **Warning** You might be tempted at times to use an `IndirectActorProducer`
+which always returns the same instance, e.g. by using a static field. This is
+not supported, as it goes against the meaning of an actor restart, which is
+described here: [What Restarting Means](Supervision#what-restarting-means).
 
-When using a dependency injection framework, there are a few things you have to keep in mind.
+When using a dependency injection framework, there are a few things you have
+to keep in mind.
 
-When scoping **Actor** type dependencies using your DI container only `TransientLifestyle` or `InstancePerDependency` like scopes are supported.
-This is due to the fact that Akka explicitly manages the lifecycle of its Actors. So any scope which interferes with that is not supported.
+When scoping actor type dependencies using your DI container, only
+`TransientLifestyle` or `InstancePerDependency` like scopes are supported.
+This is due to the fact that Akka explicitly manages the lifecycle of its
+actors. So any scope which interferes with that is not supported.
 
-This also means that when injecting dependencies into your Actor, using a `Singleton` or `Transient` scope is **fine**. But having that dependency scoped per `httpwebrequest` for example **won't** work.
+This also means that when injecting dependencies into your actor, using a
+Singleton or Transient scope is fine. But having that dependency scoped per
+httpwebrequest for example won't work.
 
-Techniques for dependency injection and integration with dependency injection frameworks are described in more depth in the [Using Akka with Dependency Injection](http://letitcrash.com/post/55958814293/akka-dependency-injection) guideline.
+Techniques for dependency injection and integration with dependency injection
+frameworks are described in more depth in the
+[Using Akka with Dependency Injection](http://letitcrash.com/post/55958814293/akka-dependency-injection)
+guideline.

--- a/src/docs/Examples of use cases for Akka.md
+++ b/src/docs/Examples of use cases for Akka.md
@@ -4,7 +4,7 @@ title: Examples of use cases for Akka
 ---
 >**Note**<br/>
 This describes how JVM Akka has been used.
-Akka.NET is still in Beta and production examples rare.
+Akka.NET is still relatively new and production examples are rare.
 
 We see Akka being adopted by many large organizations in a big range of industries all from investment and merchant banking, retail and social media, simulation, gaming and betting, automobile and traffic systems, health care, data analytics and much more. Any system that have the need for high-throughput and low latency is a good candidate for using Akka.
 

--- a/src/docs/FSM.md
+++ b/src/docs/FSM.md
@@ -34,7 +34,7 @@ public class MyFSM : FSM<int, object>
         Initialize();
     }
 
-    public ActorRef Target { get; private set; }
+    public IActorRef Target { get; private set; }
 
     protected override void PreRestart(Exception reason, object message)
     {

--- a/src/docs/FSharp API.md
+++ b/src/docs/FSharp API.md
@@ -25,7 +25,7 @@ F# also gives you it's own actor system Configuration module with support of fol
 
 Unlike C# actors, which represent object oriented nature of the language, F# is able to define an actor's logic in more functional way. It is done by using `actor` computation expression. In most of the cases, an expression inside `actor` is expected to be represented as self-invoking recursive function - also invoking an other functions while maintaining recursive cycle is allowed, i.e. to change actor's behavior or even to create more advanced constructs like Finite State Machines.
 
-It's important to remember, that each actor returning point should point to the next recursive function call - any other value returned will result in stopping current actor (see: [Actor Lifecycle](Actor lifecycle)).
+It's important to remember, that each actor returning point should point to the next recursive function call - any other value returned will result in stopping the current actor (see: [Actor Lifecycle](Actor lifecycle)).
 
 Example:
 
@@ -41,7 +41,7 @@ let aref =
             loop())
 ```
 
-Since construct used in an example above is quite popular, you may also use following shorthand functions to define message handler's behavior:
+Since the construct used in the above example is quite popular, you may also use the following shorthand functions to define the message handler's behavior:
 
 -   `actorOf (fn : 'Message -> unit) (mailbox : Actor<'Message>) : Cont<'Message, 'Returned>` - uses a function, which takes a message as the only parameter. Mailbox parameter is injected by spawning functions.
 -   `actorOf2 (fn : Actor<'Message> -> 'Message -> unit) (mailbox : Actor<'Message>) : Cont<'Message, 'Returned>` - uses a function, which takes both the message and an Actor instance as the parameters. Mailbox parameter is injected by spawning functions.
@@ -60,19 +60,19 @@ let blackHole = spawn system "black-hole" (actorOf (fun msg -> ()))
 
 #### Spawning actors
 
-Paragraph above already has shown, how actors may be created with help of the spawning function. There are several spawning function, which may be used to instantiate actors:
+The above paragraph has already shown how actors may be created with the help of a spawning function. There are several spawning functions, which may be used to instantiate actors:
 
--   `spawn (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) : ActorRef` - spawns an actor using specified actor computation expression. The actor can only be used locally.
--   `spawnOpt (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor computation expression, with custom spawn option settings. The actor can only be used locally.
--   `spawne (actorFactory : ActorRefFactory) (name : string) (expr : Expr<Actor<'Message> -> Cont<'Message, 'Returned>>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor computation expression, using an Expression AST. The actor code can be deployed remotely.
--   `spawnObj (actorFactory : ActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) : ActorRef` - spawns an actor using specified actor quotation. The actor can only be used locally.
--   `spawnObjOpt (actorFactory : ActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor quotation, with custom spawn option settings. The actor can only be used locally.
+-   `spawn (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) : IActorRef` - spawns an actor using a specified actor computation expression. The actor can only be used locally.
+-   `spawnOpt (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) (options : SpawnOption list) : IActorRef` - spawns an actor using a  specified actor computation expression, with custom spawn option settings. The actor can only be used locally.
+-   `spawne (actorFactory : IActorRefFactory) (name : string) (expr : Expr<Actor<'Message> -> Cont<'Message, 'Returned>>) (options : SpawnOption list) : IActorRef` - spawns an actor using a  specified actor computation expression, using an Expression AST. The actor code can be deployed remotely.
+-   `spawnObj (actorFactory : IActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) : IActorRef` - spawns an actor using a specified actor quotation. The actor can only be used locally.
+-   `spawnObjOpt (actorFactory : IActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) (options : SpawnOption list) : IActorRef` - spawns an actor using a specified actor quotation, with custom spawn option settings. The actor can only be used locally.
 
-All of these functions may be used with either actor system or actor itself. In the first case spawned actor will be placed under */user* root guardian of the current actor system hierarchy. In second option spawned actor will become child of the actor used as [actorFactory] parameter of the spawning function.
+All of these functions may be used with either the actor system or the actor itself. In the first case the spawned actor will be placed under */user* root guardian of the current actor system hierarchy. In the second option the spawned actor will become a child of the actor used as the  `actorFactory` parameter of the spawning function.
 
 #### Dealing with disposable resources
 
-When executing application logic inside receive function, be aware of a constant threat of stopping a current actor at any time for various reasons. This is an especially problematic situation when you're using a resource allocation - when actor will be stopped suddenly, you may be left with potentially heavy resources still waiting for being released.
+When executing application logic inside the receive function, be aware of a constant threat of stopping a current actor at any time for various reasons. This is an especially problematic situation when you are using a resource allocation - when an actor stops suddenly, you may be left with potentially heavy resources still waiting to be released.
 
 Use `mailbox.Defer (deferredFunc)` in situations when you must ensure operation to be executed at the end of the actor lifecycle.
 
@@ -96,13 +96,13 @@ To be able to specify more precise actor creation behavior, you may use `spawnOp
 
 -   `SpawnOption.Deploy(Akka.Actor.Deploy)` - defines deployment strategy for created actors (see: [[Deploy]]). This option may be used along with `spawne` function to enable remote actors deployment.
 -   `SpawnOption.Router(Akka.Routing.RouterConfig)` - defines an actor to be a router as well as it's routing specifics (see: [Routing](Routing)).
--   `SpawnOption.SupervisiorStrategy(Akka.Actor.SupervisiorStrategy)` - defines a supervisor strategy of the current actor. It will affect it's children (see: [Supervision](Supervision)).
+-   `SpawnOption.SupervisiorStrategy(Akka.Actor.SupervisiorStrategy)` - defines a supervisor strategy of the current actor. It will affect its children (see: [Supervision](Supervision)).
 -   `SpawnOption.Dispatcher(string)` - defines a type of the dispatcher used for resources management for the created actors. (See: [Dispatchers](Dispatchers))
 -   `SpawnOption.Mailbox(string)` - defines a type of the mailbox used for the created actors. (See: [Mailboxes](Mailbox))
 
 Example (deploy actor remotely):
 
-```
+```fsharp
 open Akka.Actor
 let remoteRef =
     spawne system "my-actor" <@ actorOf myFunc @>
@@ -111,7 +111,7 @@ let remoteRef =
 
 ### Ask and tell operators
 
-While you may use traditional `ActorRef.Tell` and `ActorRef.Ask` methods, it's more convenient to use dedicated `<!` and `<?` operators to perform related operations.
+While you may use traditional `IActorRef.Tell` and `IActorRef.Ask` methods, it's more convenient to use dedicated `<!` and `<?` operators to perform related operations.
 
 Example:
 
@@ -122,9 +122,9 @@ async { let! response = aref <? request }
 
 ### Actor selection
 
-Actors may be referenced not only by `ActorRef`s, but also through actor path selection (see: [Addressing](Addressing)). With F# API you may select an actor with known path using `select` function:
+Actors may be referenced not only by `IActorRef`s, but also through actor path selection (see: [Addressing](Addressing)). With the F# API you may select an actor with a known path using the `select` function:
 
--   `select (path : string) (selector : ActorRefFactory) : ActorSelection` - where path is a valid URI string used to recognize actor path, and the selector is either actor system or actor itself.
+-   `select (path : string) (selector : IActorRefFactory) : ActorSelection` - where path is a valid URI string used to recognize an actor path, and the selector is either an actor system or an actor itself.
 
 Example:
 
@@ -137,7 +137,7 @@ aref2 <! "two"
 
 ### Inboxes
 
-Inboxes are actor-like objects used to be listened by other actors. They are a good choice to watch over other actors lifecycle. Some of the inbox-related functions may block current thread and therefore should not be used inside actors.
+Inboxes are actor-like objects used to listen to other actors. They are a good choice to watch over other actors lifecycle. Some of the inbox-related functions may block current thread and therefore should not be used inside actors.
 
 -   `inbox (system : ActorSystem) : Inbox` - creates a new inbox in provided actor system scope.
 -   `receive (timeout : TimeSpan) (i : Inbox) : 'Message option` - receives a next message sent to the inbox. This is a blocking operation. Returns `None` if timeout occurred or message is incompatible with expected response type.
@@ -160,8 +160,8 @@ akka {
 
 Actors and Inboxes may be used to monitor lifetime of other actors. This is done by `monitor`/`demonitor` functions:
 
--   `monitor (subject: ActorRef) (watcher: ICanWatch) : ActorRef` - starts monitoring a referred actor.
--   `demonitor (subject: ActorRef) (watcher: ICanWatch) : ActorRef` - stops monitoring of the previously monitored actor.
+-   `monitor (subject: IActorRef) (watcher: ICanWatch) : IActorRef` - starts monitoring a referred actor.
+-   `demonitor (subject: IActorRef) (watcher: ICanWatch) : IActorRef` - stops monitoring of the previously monitored actor.
 
 Monitored actors will automatically send a `Terminated` message to their watchers when they die.
 
@@ -170,11 +170,11 @@ Monitored actors will automatically send a `Terminated` message to their watcher
 Actors have a place in their system's hierarchy trees. To manage failures done by the child actors, their parents/supervisors may decide to use specific supervisor strategies (see: [Supervision](Supervision)) in order to react to the specific types of errors. In F# this may be configured using functions of the `Strategy` module:
 
 -   `Strategy.OneForOne (decider : exn -> Directive) : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution.
--   `Strategy.OneForOne (decider : exn -> Directive, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution. [retries] param defines a number of times, an actor could be restarted. If it's a negative value, there is not limit. [timeout] param defines a time window for number of retries to occur.
--   `OneForOne (decider : Expr<(exn -> Directive)>, ?retries : int, ?timeout : TimeSpan)  : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution. [retries] param defines a number of times, an actor could be restarted. If it's a negative value, there is not limit. [timeout] param defines a time window for number of retries to occur. **Strategies created this way may be serialized and deserialized on remote nodes** .
+-   `Strategy.OneForOne (decider : exn -> Directive, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution. The `retries` parameter defines a number of times an actor could be restarted. If it's a negative value, there is no limit. The `timeout` parameter defines a time window for the  number of retries to occur.
+-   `OneForOne (decider : Expr<(exn -> Directive)>, ?retries : int, ?timeout : TimeSpan)  : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution. The `retries` parameter defines a number of times an actor could be restarted. If it's a negative value, there is no limit. The `timeout` parameter defines a time window for the number of retries to occur. **Strategies created this way may be serialized and deserialized on remote nodes** .
 -   `Strategy.AllForOne (decider : exn -> Directive) : SupervisorStrategy` - returns a supervisor strategy applicable to each supervised actor when any of them had faulted during execution.
--   `Strategy.AllForOne (decider : exn -> Directive, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` -  returns a supervisor strategy applicable to each supervised actor when any of them had faulted during execution. [retries] param defines a number of times, an actor could be restarted. If it's a negative value, there is not limit. [timeout] param defines a time window for number of retries to occur.
--   `AllForOne (decider : Expr<(exn -> Directive)>, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` - returns a supervisor strategy applicable to each supervised actor when any of them had faulted during execution. [retries] param defines a number of times, an actor could be restarted. If it's a negative value, there is not limit. [timeout] param defines a time window for number of retries to occur. **Strategies created this way may be serialized and deserialized on remote nodes** .
+-   `Strategy.AllForOne (decider : exn -> Directive, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` -  returns a supervisor strategy applicable to each supervised actor when any of them had faulted during execution. The `retries` parameter defines a number of times an actor could be restarted. If it's a negative value, there is no limit. The `timeout` parameter defines a time window for the number of retries to occur.
+-   `AllForOne (decider : Expr<(exn -> Directive)>, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` - returns a supervisor strategy applicable to each supervised actor when any of them had faulted during execution. The `retries` parameter defines a number of times an actor could be restarted. If it's a negative value, there is no limit. The `timeout` parameter defines a time window for the number of retries to occur. **Strategies created this way may be serialized and deserialized on remote nodes** .
 
 Example:
 
@@ -197,10 +197,10 @@ let remoteRef =
 
 ### Publish/Subscribe support
 
-While you may use built-in set of the event stream methods (see: Event Streams), there is an option of using dedicated F# API functions:
+While you may use built-in set of the event stream methods (see: [Event Streams]), there is an option of using the dedicated F# API functions:
 
--   `subscribe (channel: System.Type) (ref: ActorRef) (eventStream: Akka.Event.EventStream) : bool` - subscribes an actor reference to target channel of the provided event stream. Channels are associated with specific types of a message emitted by the publishers.
--   `unsubscribe (channel: System.Type) (ref: ActorRef) (eventStream: Akka.Event.EventStream) : bool` - unsubscribes an actor reference from target channel of the provided event stream.
+-   `subscribe (channel: System.Type) (ref: IActorRef) (eventStream: Akka.Event.EventStream) : bool` - subscribes an actor reference to the target channel of the provided event stream. Channels are associated with specific types of a message emitted by the publishers.
+-   `unsubscribe (channel: System.Type) (ref: IActorRef) (eventStream: Akka.Event.EventStream) : bool` - unsubscribes an actor reference from the target channel of the provided event stream.
 -   `publish (event: 'Event) (eventStream: Akka.Event.EventStream) : unit` - publishes an event on the provided event stream. Event channel is resolved from event's type.
 
 Example:
@@ -233,7 +233,7 @@ publisher  <! Msg (publisher, "hello again")
 
 ### Logging
 
-F# API supports two groups of logging functions - one that operates directly on strings and second (which may be recognized by *f* suffix in function names) which operates using F# string formatting features. Major difference is performance - first one is less powerful, but it's also faster than the second one.
+The F# API supports two groups of logging functions - one that operates directly on strings and another (which may be recognized by *f* suffix in function names) that operates using F# string formatting features. The major difference is performance - the former is less powerful, but it's also faster than the latter.
 
 Both groups support logging on various levels (DEBUG, &lt;default&gt; INFO, WARNING and ERROR). Actor system's logging level may be managed through configuration, i.e.:
 
@@ -260,9 +260,9 @@ F# API provides following logging methods:
 
 ### Interop with Task Parallel Library
 
-Since both TPL an Akka frameworks can be used for parallel processing, sometimes they need to work both inside the same application.
+Since both TPL and Akka frameworks can be used for parallel processing, sometimes they need to work both inside the same application.
 
-To operate directly between `Async` results and actors, use `pipeTo` function (and it's abbreviations in form of `<!|` and `|!>` operators) to inform actor about tasks ending their processing pipelines. Piping functions used on tasks will move async result directly to the mailbox of a target actor.
+To operate directly between `Async` results and actors, use `pipeTo` function (and its abbreviations in the form of `<!|` and `|!>` operators) to inform actor about tasks ending their processing pipelines. Piping functions used on tasks will move async result directly to the mailbox of a target actor.
 
 Example:
 

--- a/src/docs/Getting started.md
+++ b/src/docs/Getting started.md
@@ -55,7 +55,7 @@ using Akka.Actor;
 
 namespace ConsoleApplication11
 {
-    //Create an (immutable) message type that your actor will respond to
+    // Create an (immutable) message type that your actor will respond to
     public class Greet
     {
         public Greet(string who)
@@ -74,7 +74,7 @@ namespace ConsoleApplication11
 }
 ```
 
-Once we have the message type, we can create our Actor:
+Once we have the message type, we can create our actor:
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -153,18 +153,20 @@ namespace ConsoleApplication11
     {
         static void Main(string[] args)
         {
-            //create a new actor system (a container for your actors)
+            // Create a new actor system (a container for your actors)
             var system = ActorSystem.Create("MySystem");
-            //create your actor and get a reference to it.
-            //this will be an "ActorRef", which is not a
-            //reference to the actual actor instance
-            //but rather a client or proxy to it
+
+            // Create your actor and get a reference to it.
+            // This will be an "ActorRef", which is not a
+            // reference to the actual actor instance
+            // but rather a client or proxy to it.
             var greeter = system.ActorOf<GreetingActor>("greeter");
-            //send a message to the actor
+
+            // Send a message to the actor
             greeter.Tell(new Greet("World"));
 
-            //this prevents the app from exiting
-            //Before the async work is done
+            // This prevents the app from exiting
+            // before the async work is done
             Console.ReadLine();
         }
     }

--- a/src/docs/Logging.md
+++ b/src/docs/Logging.md
@@ -17,7 +17,7 @@ _log.Debug("Some message");
 ```
 
 ## Standard Loggers
-Akka .NET comes with two built in loggers.
+Akka.NET comes with two built in loggers.
 
 * __StandardOutLogger__
 * __BusLogging__
@@ -43,7 +43,7 @@ akka {
 
 ## Logging Unhandled messages
 
-It is possible to configure akka so that Unhandled Messages are logged as Debug log events for debug purposes. This can be achieved using the following configuration setting:
+It is possible to configure akka so that Unhandled messages are logged as Debug log events for debug purposes. This can be achieved using the following configuration setting:
 
 ```hocon
 akka {

--- a/src/docs/Persistence.md
+++ b/src/docs/Persistence.md
@@ -4,71 +4,71 @@ title: Persistence
 ---
 ## Persistence
 
-Akka.Persistence plugin enables to create a stateful actors, which internal state may be stored inside persistent data storage and used for recovery in case of restart, migration or VM crash. Core concept behind Akka persistence lays in storing not only actor state directly (in form of the snapshots) but also history of all of the changes of that actor's state. This is quite useful solution common in patterns such as eventsourcing. Changes are immutable by nature, as they describe facts already reported in the history, and can be stored inside event journal in append-only mode. While recovering, actor restores it's state from the latests snapshot available - which can reduce recovery time - and then recreates it further by replaying events stored inside journal. Among other features provided by persistence plugin is support for command query segregation model and point-to-point communication with at-least-once delivery semantics.
+Akka.Persistence plugin enables the creation of stateful actors whose internal state may be stored inside persistent data storage and used for recovery in case of restart, migration or VM crash. The core concept behind Akka persistence lays in storing not only the actor's state directly (in the form of snapshots) but also history of all of the changes of that actor's state. This is quite  useful solution common in patterns such as eventsourcing. Changes are immutable by nature, as they describe facts already reported in the history, and can be stored inside event journal in append-only mode. While recovering, the actor restores it's state from the latests snapshot available - which can reduce recovery time - and then recreates it further by replaying events stored inside the journal. Among other features provided by the persistence plugin is support for command query segregation model and point-to-point communication with [at-least-once](concepts/message-delivery-reliability#discussion-what-does-at-most-once-mean-) delivery semantics.
 
 ### Architecture
 
 Akka.Persistence features are available through new set of actor base classes:
 
-- `PersistentActor` is a persistent, stateful equivalent of *ActorBase* class. It's able to persist event inside the journal, creating snapshots in snapshot stores and recover from them in thread-safe manner. It can be used for both changing and reading state of the actor.
-- `PersistentView` is used to recreate internal state of other persistent actor based on journaled messages. It works in read-only manner - it cannot journal any event by itself.
-- `GuaranteedDeliveryActor` may be used to ensure at-least-once delivery semantics between communicating actors, even in case when either sender or receiver VM crashes.
-- `Journal` stores a sequence of events send by the persistent actor. The storage backend of the journal is pluggable. By default it uses in-memory message stream and is NOT a persistent storage.
+- `PersistentActor` is a persistent, stateful equivalent of the `ActorBase` class. It's able to persist events inside the journal, creating snapshots in snapshot stores and recover from them in a  thread-safe manner. It can be used for both changing and reading state of the actor.
+- `PersistentView` is used to recreate the internal state of other persistent actor based on journaled messages. It works in a read-only manner - it cannot journal any event by itself.
+- `GuaranteedDeliveryActor` may be used to ensure [at-least-once](concepts/message-delivery-reliability#discussion-what-does-at-most-once-mean-) delivery semantics between communicating actors, even in case when either sender or receiver VM crashes.
+- `Journal` stores a sequence of events send by the persistent actor. The storage backend of the journal is pluggable. By default it uses an in-memory message stream and is NOT a persistent storage.
 - `Snapshot store` is used to persist snapshots of either persistent actor's or view's internal state. They can be used to reduce recovery times in case when a lot of events needs to be replayed for specific persistent actor. Storage backend of the snapshot store is pluggable. By default it uses local file system.
 
 ### Persistent actors
 
-Unlike default `ActorBase` class `PersistentActor` and it's derivatives requires to setup a few more additional members:
+Unlike the default `ActorBase` class, `PersistentActor` and it's derivatives requires the setup of a few more additional members:
 
 - `PersistenceId` is a persistent actor's identifier that doesn't change across different actor incarnations. It's used to retrieve an event stream required by the persistent actor to recover it's internal state.
-- `ReceiveRecover` is a method invoked during actor's recovery cycle. Incoming objects may be user-defined events as well as system messages, for example `SnapshotOffer` which is used to deliver latest actor state saved in the snapshot store.
-- `ReceiveCommand` is an equivalent of basic `Receive` method of default Akka.NET actors.
+- `ReceiveRecover` is a method invoked during an actor's recovery cycle. Incoming objects may be user-defined events as well as system messages, for example `SnapshotOffer` which is used to deliver latest actor state saved in the snapshot store.
+- `ReceiveCommand` is an equivalent of the basic `Receive` method of default Akka.NET actors.
 
 Persistent actors also offer a set of specialized members:
 
-- `Persist` and `PersistAsync` methods can be used to send events to event journal in order to store them inside. Second argument in a callback invoked when journal confirms, that events have been stored successfully.
-- `Defer` and `DeferAsync` are used to perform various operations *after* events will be persisted and their callback handlers will be invoked. Unlike persist methods, defer won't store and event in a persistent storage. Defer methods may NOT be invoked in case when actor is restarted even thou journal will successfully persist events sent.
+- `Persist` and `PersistAsync` methods can be used to send events to the event journal in order to store them inside. The second argument is a callback invoked when the journal confirms that events have been stored successfully.
+- `Defer` and `DeferAsync` are used to perform various operations *after* events will be persisted and their callback handlers will be invoked. Unlike the persist methods, defer won't store an event in persistent storage. Defer methods may NOT be invoked in case when the actor is restarted even though the journal will successfully persist events sent.
 - `DeleteMessages` will order attached journal to remove part of it's events. It can be either logical deletion - messages are marked as deleted, but are not removed physically from the backend storage - or a physical one, when the messages are removed physically from the journal.
-- `LoadSnapshot` will sent request to snapshot store to resent a current actor's snapshot.
-- `SaveSnapshot` will sent current actor's internal state as snapshot to be saved by configured snapshot store.
-- `DeleteSnapshot` and `DeleteSnapshots` methods may be used to specify snapshots to be removed from snapshot store in case, when they are no longer needed.
-- `OnReplaySuccess` is a virtual method which will be called when recovery cycle will end successfully.
-- `OnReplayFailure` is a virtual method which will be called when recovery cycle will fail unexpectedly from some reason.
-- `IsRecovering` property determines if current actor is performing a recovery cycle at the moment.
-- `SnapshotSequenceNr` property may be used to determine sequence number used for marking persisted events. This value is changing in monotically increasing manner.
+- `LoadSnapshot` will send a request to the snapshot store to resend the current actor's snapshot.
+- `SaveSnapshot` will send the current actor's internal state as a snapshot to be saved by the configured snapshot store.
+- `DeleteSnapshot` and `DeleteSnapshots` methods may be used to specify snapshots to be removed from the snapshot store in cases where they are no longer needed.
+- `OnReplaySuccess` is a virtual method which will be called when the recovery cycle ends successfully.
+- `OnReplayFailure` is a virtual method which will be called when the recovery cycle fails unexpectedly from some reason.
+- `IsRecovering` property determines if the current actor is performing a recovery cycle at the moment.
+- `SnapshotSequenceNr` property may be used to determine the sequence number used for marking persisted events. This value changes in a monotonically increasing manner.
 
-In case when a manual recovery cycle initialization is necessary, it may be invoked by sending a `Recover` message to persistent actor.
+In case a manual recovery cycle initialization is necessary, it may be invoked by sending a `Recover` message to a persistent actor.
 
 ### Persistent views
 
-While persistent actor may be used to producing and persisting an events, views are used only to read internal state based on them. Like persistent actor, view has a `PersistenceId` to specify collection of events to be resent to current view. This value should however be correlated with PersistentId of actor - producer of the events.
+While a persistent actor may be used to produce and persist events, views are used only to read internal state based on them. Like the persistent actor, a view has a `PersistenceId` to specify a  collection of events to be resent to current view. This value should however be correlated with the  `PersistentId` of an actor who is the producer of the events.
 
 Other members:
 
-- `ViewId` property is an view unique identifier that doesn't change across different actor incarnations. It's useful in case when there should be a multiple different views associated with a single persistent actor, but showing it's state from a different perspectives.
-- `IsAutoUpdate` property determines if view will try to automatically update it's state in specified time intervals. Without it, view won't update it's state until it receives an explicit `Update` message. This value can be set through configuration with *akka.persistence.view.auto-update* set to either *on* (by default) or *off*.
-- `AutoUpdateInterval` specifies time interval in which view will be updating itself - only in case when *IsAutoUpdate* flag is on. This value can be set through configuration with *akka.persistence.view.auto-update-interval* key (5 seconds by default).
-- `AutoUpdateReplayMax` property determines maximum number of events to be replayed during a single *Update* cycle. This value can be set through configuration with *akka.persistence.view.auto-update-replay-max* key (by default it's -1 - no limit).
-- `LoadSnapshot` will sent request to snapshot store to resent a current view's snapshot.
-- `SaveSnapshot` will sent current view's internal state as snapshot to be saved by configured snapshot store.
-- `DeleteSnapshot` and `DeleteSnapshots` methods may be used to specify snapshots to be removed from snapshot store in case, when they are no longer needed.
+- `ViewId` property is a view unique identifier that doesn't change across different actor incarnations. It's useful in cases where there are multiple different views associated with a single persistent actor, but showing its state from a different perspectives.
+- `IsAutoUpdate` property determines if the view will try to automatically update its state in specified time intervals. Without it, the view won't update its state until it receives an explicit `Update` message. This value can be set through configuration with *akka.persistence.view.auto-update* set to either *on* (by default) or *off*.
+- `AutoUpdateInterval` specifies a time interval in which the view will be updating itself - only in cases where the *IsAutoUpdate* flag is on. This value can be set through configuration with *akka.persistence.view.auto-update-interval* key (5 seconds by default).
+- `AutoUpdateReplayMax` property determines the maximum number of events to be replayed during a single *Update* cycle. This value can be set through configuration with *akka.persistence.view.auto-update-replay-max* key (by default it's -1 - no limit).
+- `LoadSnapshot` will send a request to the snapshot store to resend a current view's snapshot.
+- `SaveSnapshot` will send the current view's internal state as a snapshot to be saved by the  configured snapshot store.
+- `DeleteSnapshot` and `DeleteSnapshots` methods may be used to specify snapshots to be removed from the snapshot store in cases where they are no longer needed.
 
 ### Guaranteed delivery
 
-Guaranteed delivery actors are specializations of persistent actors and may be used to provide at-least-once delivery semantics, even in case when one of the communication endpoints will crash. Because it's possible that the same message will be send twice, actor's receive behavior must work in the idempotent manner.
+Guaranteed delivery actors are specializations of persistent actors and may be used to provide [at-least-once](concepts/message-delivery-reliability#discussion-what-does-at-most-once-mean-) delivery semantics, even in cases where one of the communication endpoints crashes. Because it's possible that the same message will be send twice, actor's receive behavior must work in the idempotent manner.
 
 Members:
 
-- `Deliver` method is used to send message to another actor in at-least-once delivery semantics. Message sent this way must be confirmed by the other endpoint with `ConfirmDelivery` method. Otherwise it will be resend again and again until the redelivery limit will be reached.
-- `GetDeliverySnapshot` and `SetDeliverySnapshot` methods are used as part of delivery snapshotting strategy. They return/reset state of the current guaranteed delivery actor unconfirmed messages. In order to save custom deliverer state inside snapshot, a returned delivery snapshot should be included into that snapshot and reset in *ReceiveRecovery* method, when `SnapshotOffer` arrives.
-- `RedeliveryBurstLimit` is a virtual property which determines maximum number of unconfirmed messages to be send in each redelivery attempt. It may be useful to prevent message overflow scenarios. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.redelivery-burst-limit* path (10 000 by default).
-- `UnconfirmedDeliveryAttemptsToWarn` is a virtual property which determines, how many unconfirmed deliveries may be sent before guaranteed delivery actor will send an `UnconfirmedWarning` message to itself. Count is reset after actor's restart. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.warn-after-number-of-unconfirmed-attempts* path (5 by default).
-- `MaxUnconfirmedMessages` is a virtual property which determines maximum of unconfirmed deliveries hold in memory. After this threshold is exceeded any `Deliver` method will raise `MaxUnconfirmedMessagesExceededException`. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.max-unconfirmed-messages* path (100 000 by default).
-- `UnconfirmedCount` property shows a number of the unconfirmed messages.
+- `Deliver` method is used to send a message to another actor in [at-least-once](concepts/message-delivery-reliability#discussion-what-does-at-most-once-mean-) delivery semantics. A message sent this way must be confirmed by the other endpoint with the  `ConfirmDelivery` method. Otherwise it will be resent again and again until the redelivery limit is reached.
+- `GetDeliverySnapshot` and `SetDeliverySnapshot` methods are used as part of a delivery snapshotting strategy. They return/reset state of the current guaranteed delivery actor's unconfirmed messages. In order to save custom deliverer state inside a snapshot, a returned delivery snapshot should be included in that snapshot and reset in *ReceiveRecovery* method, when `SnapshotOffer` arrives.
+- `RedeliveryBurstLimit` is a virtual property which determines the maximum number of unconfirmed messages to be send in each redelivery attempt. It may be useful in preventing message overflow scenarios. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.redelivery-burst-limit* path (10 000 by default).
+- `UnconfirmedDeliveryAttemptsToWarn` is a virtual property which determines how many unconfirmed deliveries may be sent before guaranteed delivery actor will send an `UnconfirmedWarning` message to itself. The count is reset after the actor's restart. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.warn-after-number-of-unconfirmed-attempts* path (5 by default).
+- `MaxUnconfirmedMessages` is a virtual property which determines the maximum number of unconfirmed deliveries to hold in memory. After this threshold is exceeded, any `Deliver` method will raise `MaxUnconfirmedMessagesExceededException`. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.max-unconfirmed-messages* path (100 000 by default).
+- `UnconfirmedCount` property shows the number of unconfirmed messages.
 
 ### Journals
 
-Journal is a specialized type of an actor, which exposes an API to handle incoming events and store them in backend storage. By default Akka.Persitence uses a `MemoryJournal` which stores all events in memory and therefore it's not a persistent storage. Custom journal configuration path may be specified inside *akka.persistence.journal.plugin* path and by default it requires two keys set: *class* and *plugin-dispatcher*. Example configuration:
+Journal is a specialized type of actor which exposes an API to handle incoming events and store them in backend storage. By default Akka.Persitence uses a `MemoryJournal` which stores all events in memory and therefore it's not persistent storage. A custom journal configuration path may be specified inside *akka.persistence.journal.plugin* path and by default it requires two keys set: *class* and *plugin-dispatcher*. Example configuration:
 
 ```hocon
 akka {
@@ -94,7 +94,7 @@ akka {
 
 ### Snapshot store
 
-Snapshot store is a specialized type of an actor, which exposes an API to handle incoming snapshot-related requests and is able to save snapshots in some backend storage. By default Akka.Persistence uses a `LocalSnapshotStore`, which uses a local file system as a storage. Custom snapshot store configuration path may be specified inside *akka.persistence.snapshot-store.plugin* path and by default it requires two keys set: *class* and *plugin-dispatcher*. Example configuration:
+Snapshot store is a specialized type of actor which exposes an API to handle incoming snapshot-related requests and is able to save snapshots in some backend storage. By default Akka.Persistence uses a `LocalSnapshotStore`, which uses a local file system as storage. A custom snapshot store configuration path may be specified inside *akka.persistence.snapshot-store.plugin* path and by default it requires two keys set: *class* and *plugin-dispatcher*. Example configuration:
 
 ```hocon
 akka {
@@ -126,4 +126,4 @@ akka {
 
 ### Contributing
 
-Akka persistence plugin gives a custom journal and snapshot store creator a built-in set of test, which can be used to verify correctness of the implemented backend storage plugins. It's available through `Akka.Persistence.TestKit` package and uses xUnit as default test framework.
+Akka persistence plugin gives a custom journal and snapshot store creator a built-in set of tests, which can be used to verify correctness of the implemented backend storage plugins. It's available through `Akka.Persistence.TestKit` package and uses [xUnit](http://xunit.github.io/) as the default test framework.

--- a/src/docs/Props.md
+++ b/src/docs/Props.md
@@ -4,69 +4,94 @@ title: Props
 ---
 ## Props
 
-Props is a configuration class to specify options for the creation of actors, think of it as an immutable and thus freely shareable recipe for creating an actor including associated deployment information (e.g. which dispatcher to use, see more below). Here are some examples of how to create a Props instance.
+Props is a configuration class to specify options for the creation of actors,
+think of it as an immutable and thus freely shareable recipe for creating an
+actor including associated deployment information (e.g. which dispatcher to
+use, see more below). Here are some examples of how to create a Props instance.
 ```csharp
-  Props props1 = Props.Create(typeof(MyActor));
-  Props props2 = Props.Create(() => new MyActor(..), "...");
-  Props props3 = Props.Create<MyActor>();
+Props props1 = Props.Create(typeof(MyActor));
+Props props2 = Props.Create(() => new MyActor(..), "...");
+Props props3 = Props.Create<MyActor>();
 ```
 
 >**Warning**<br/>
-In the second line, using `new`; Do note that the arguments passed in will be evaluated *once*, when the `Props` are created.
-This is because the arguments can be passed to remote systems for [remote deployment](Remote deploy).
-The behavior is somewhat odd since a lambda containing a `new` statement generally evaluate the entire expression every time it is invoked.
+In the second line, using `new`; Do note that the arguments passed in will be
+evaluated *once*, when the `Props` are created. This is because the arguments
+can be passed to remote systems for [remote deployment](Remote deploy).
+The behavior is somewhat odd since a lambda containing a `new` statement
+generally evaluates the entire expression every time it is invoked.
 
 ### Recommended Practices
-It is a good idea to provide static factory methods on the UntypedActor which help keeping the creation of suitable Props as close to the actor definition as possible. This also allows usage of the Creator-based methods which statically verify that the used constructor actually exists instead relying only on a runtime check.
+It is a good idea to provide static factory methods on the `UntypedActor` which
+help keep the creation of suitable `Props` as close to the actor definition as
+possible. This also allows usage of the Creator-based methods which statically
+verify that the used constructor actually exists instead of relying only on a
+runtime check.
 ```csharp
-public class DemoActor : ReceiveActor {
+public class DemoActor : ReceiveActor
+{
+    /// <summary>
+    /// Create Props for an actor of this type.
+    /// </summary>
+    /// <param name="magicNumber">
+    /// The magic number to be passed to this actor’s constructor.
+    /// </param>
+    /// <returns>
+    /// A Props for creating this actor, which can then be further configured
+    /// (e.g. calling `.withDispatcher()` on it)
+    /// </returns>
+    public static Props Props(int magicNumber)
+    {
+        return Props.Create(() => new DemoActor(magicNumber));
+    }
 
-  /**
-   * Create Props for an actor of this type.
-   * @param magicNumber The magic number to be passed to this actor’s constructor.
-   * @return a Props for creating this actor, which can then be further configured
-   *         (e.g. calling `.withDispatcher()` on it)
-   */
-  public static Props Props(int magicNumber)
-  {
-    return Props.Create(() => new DemoActor(magicNumber));
-  }
+    private int magicNumber;
 
-  private int magicNumber;
-
-  public DemoActor(int magicNumber)
-  {
-    this.magicNumber = magicNumber;
-    ...some receive declarations here
-    //Receive<string>(str => ..);
-  }
+    public DemoActor(int magicNumber)
+    {
+        this.magicNumber = magicNumber;
+        ...some receive declarations here
+        //Receive<string>(str => ..);
+    }
 }
 
 system.ActorOf(DemoActor.Props(42), "demo");
 ```
 ### Creating Actors with Props
-Actors are created by passing a Props instance into the `ActorOf` factory method which is available on `ActorSystem` and `ActorContext`.
+Actors are created by passing a Props instance into the `ActorOf` factory method
+which is available on `ActorSystem` and `ActorContext`.
 
 ```csharp
 // ActorSystem is a heavy object: create only one per application
 ActorSystem system = ActorSystem.Create("MySystem");
-ActorRef myActor = system.ActorOf(Props.Create(typeof(MyActor)),
-  "myactor");
+ActorRef myActor = system.ActorOf(Props.Create(typeof(MyActor)), "myactor");
 ```
-Using the ActorSystem will create top-level actors, supervised by the actor system’s provided guardian actor, while using an actor’s context will create a child actor.
+Using the `ActorSystem` will create top-level actors, supervised by the actor
+system’s provided guardian actor, while using an actor’s context will create
+a child actor.
 
 ```csharp
-class A : ReceiveActor
+public class A : ReceiveActor
 {
-  ActorRef child =
-      Context.ActorOf(Props.Create(typeof(MyActor)), "myChild");
-  // plus some behavior ...
+    IActorRef child = Context.ActorOf(Props.Create(typeof(MyActor)), "myChild");
+    // plus some behavior ...
 }
 ```
-It is recommended to create a hierarchy of children, grand-children and so on such that it fits the logical failure-handling structure of the application, see [[Actor Systems]].
+It is recommended to create a hierarchy of children, grand-children and so on
+such that it fits the logical failure-handling structure of the application,
+see [Actor Systems](ActorSystem).
 
-The call to `ActorOf` returns an instance of `ActorRef`. This is a handle to the actor instance and the only way to interact with it. The `ActorRef` is immutable and has a one to one relationship with the Actor it represents. The `ActorRef` is also serializable and network-aware. This means that you can serialize it, send it over the wire and use it on a remote host and it will still be representing the same Actor on the original node, across the network.
+The call to `ActorOf` returns an instance of `IActorRef`. This is a handle to
+the actor instance and the only way to interact with it. The `IActorRef` is
+immutable and has a one to one relationship with the Actor it represents.
+The `IActorRef` is also serializable and network-aware. This means that you can
+serialize it, send it over the wire and use it on a remote host and it will
+still be representing the same actor on the original node, across the network.
 
-The name parameter is optional, but you should preferably name your actors, since that is used in log messages and for identifying actors. The name must not be empty or start with $, but it may contain URL encoded characters (eg. `%20` for a blank space). If the given name is already in use by another child to the same parent an `InvalidActorNameException` is thrown.
+The name parameter is optional, but you should preferably name your actors,
+since that is used in log messages and for identifying actors. The name must
+not be empty or start with $, but it may contain URL encoded characters
+(eg. `%20` for a blank space). If the given name is already in use by another
+child to the same parent an `InvalidActorNameException` is thrown.
 
 Actors are automatically started asynchronously when created.

--- a/src/docs/Serilog.md
+++ b/src/docs/Serilog.md
@@ -5,7 +5,8 @@ title: Serilog
 # Using Serilog
 
 ## Setup
-Install the package __Akka.Logger.Serilog__ to utilize [Serilog](http://serilog.net/)
+Install the package __Akka.Logger.Serilog__ to utilize
+[Serilog](http://serilog.net/)
 
 ```
 PM> Install-Package Akka.Logger.Serilog
@@ -13,26 +14,28 @@ PM> Install-Package Akka.Logger.Serilog
 
 This will also install the required Serilog packages.
 
-Next, you'll need to configure the global `Log.Logger` and also specify to use the logger in the config when creating the system, for example like this:
-``` C#
+Next, you'll need to configure the global `Log.Logger` and also specify to use
+the logger in the config when creating the system, for example like this:
+```csharp
 var logger = new LoggerConfiguration()
 	.WriteTo.ColoredConsole()
 	.MinimumLevel.Information()
 	.CreateLogger();
 Serilog.Log.Logger = logger;
-var system = ActorSystem.Create("my-test-system", "akka { logLevel=INFO,  loggers=[\"Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog\"]}");
+var system = ActorSystem.Create("my-test-system", "akka { logLevel=INFO,  loggers=['Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog']}");
 ```
 
 ## Logging
-To log inside an actor, using the normal `string.Format()` syntax, get the logger and log:
-``` C#
+To log inside an actor, using the normal `string.Format()` syntax, get the
+logger and log:
+```csharp
 var log = Context.GetLogger();
 ...
 log.Info("The value is {0}", counter);
 ```
 
 To log using Serilog syntax you need to use the `SerilogLogMessageFormatter`:
-``` C#
+```csharp
 var log = Context.GetLogger(new SerilogLogMessageFormatter());
 ...
 log.Info("The value is {Counter}", counter);

--- a/src/docs/The Obligatory Hello World.md
+++ b/src/docs/The Obligatory Hello World.md
@@ -8,7 +8,7 @@ This example shows how to define and consume actors in both C# and F#
 ## Hello World using the C# API
 #### Define a message:
 ```csharp
-//Create an (immutable) message type that your actor will respond to
+// Create an (immutable) message type that your actor will respond to
 public class Greet
 {
     public Greet(string who)
@@ -20,7 +20,7 @@ public class Greet
 ```
 #### Define your actor using the `ReceiveActor` API
 ```csharp
-//Create the actor class
+// Create the actor class
 public class GreetingActor : ReceiveActor
 {
     public GreetingActor()
@@ -44,17 +44,19 @@ public class GreetingActor : TypedActor , IHandle<Greet>
 
 #### Usage:
 ```csharp
-//create a new actor system (a container for your actors)
+// Create a new actor system (a container for your actors)
 var system = ActorSystem.Create("MySystem");
-//create your actor and get a reference to it.
-//this will be an "ActorRef", which is not a reference to the actual actor instance
-//but rather a client or proxy to it
+
+// Create your actor and get a reference to it.
+// This will be an "IActorRef", which is not a reference to the actual actor
+// instance but rather a client or proxy to it.
 var greeter = system.ActorOf<GreetingActor>("greeter");
-//send a message to the actor
+
+// Send a message to the actor.
 greeter.Tell(new Greet("World"));
 
-//this prevents the app from exiting
-//Before the async work is done
+// This prevents the app from exiting
+// before the async work is done.
 Console.ReadLine();
 ```
 See also:

--- a/src/docs/Working with actors.md
+++ b/src/docs/Working with actors.md
@@ -61,7 +61,7 @@ using System.Diagnostics;
 ...
 var inbox = Inbox.Create(system);
 inbox.Watch(target);
-target.Tell(PoisonPill.Instance, ActorRef.NoSender);
+target.Tell(PoisonPill.Instance, ActorRefs.NoSender);
 
 try
 {
@@ -100,25 +100,30 @@ This strategy is typically declared inside the actor in order to have access to 
 The remaining visible methods are user-overridable life-cycle hooks which are described in the following:
 
 ```csharp
-public override void PreStart() {
+public override void PreStart()
+{
 }
 
-protected override void PreRestart(Exception reason, object message) {
-  foreach (ActorRef each in Context.GetChildren()) {
-    Context.Unwatch(each);
-    Context.Stop(each);
-  }
-  PostStop();
+protected override void PreRestart(Exception reason, object message)
+{
+    foreach (ActorRef each in Context.GetChildren())
+    {
+      Context.Unwatch(each);
+      Context.Stop(each);
+    }
+    PostStop();
 }
 
-protected override void PostRestart(Exception reason) {
+protected override void PostRestart(Exception reason)
+{
   PreStart();
 }
 
-protected override void PostStop() {
+protected override void PostStop()
+{
 }
 ```
-The implementations shown above are the defaults provided by the UntypedActor class.
+The implementations shown above are the defaults provided by the `UntypedActor` class.
 
 
 ## Identifying Actors via Actor Selection
@@ -269,20 +274,23 @@ This example demonstrates Ask together with the Pipe Pattern on Tasks, because t
 
 Using Ask will send a message to the receiving Actor as with Tell, and the receiving actor must reply with  `Sender.Tell(reply, Self)` in order to complete the returned Task with a value. The Ask operation involves creating an internal actor for handling this reply, which needs to have a timeout after which it is destroyed in order not to leak resources; see more below.
 
->**Warning**<br/>
->To complete the Task with an exception you need send a Failure message to the sender. This is not done automatically when an actor throws an exception while processing a message.
+>**Warning**<br/> To complete the Task with an exception you need send a Failure
+message to the sender. This is not done automatically when an actor throws an
+exception while processing a message.
 
 ```csharp
-try {
+try
+{
     var result = operation();
     Sender.Tell(result, Self);
 }
-catch (Exception e) {
+catch (Exception e)
+{
     Sender.Tell(new Failure { Exception = e }, Self);
 }
 ```
 
-If the actor does not complete the task, it will expire after the timeout period, specified as parameter to the Ask method, and the task will be cancelled and throw a TaskCancelledException.
+If the actor does not complete the task, it will expire after the timeout period, specified as parameter to the Ask method, and the task will be cancelled and throw a `TaskCancelledException`.
 
 For more information on Tasks, check out the [MSDN documentation](https://msdn.microsoft.com/en-us/library/dd537609(v=vs.110).aspx).
 
@@ -297,7 +305,7 @@ target.Forward(result, Context);
 ```
 
 ## Receive messages
-When an actor receives a message it is passed into the OnReceive method, this is an abstract method on the UntypedActor base class that needs to be defined.
+When an actor receives a message it is passed into the ```OnReceive``` method, this is an abstract method on the `UntypedActor` base class that needs to be defined.
 
 Here is an example:
 ```csharp
@@ -349,7 +357,7 @@ protected override void PostStop() {
 ```
 
 >**Note**<br/>
-Since stopping an actor is asynchronous, you cannot immediately reuse the name of the child you just stopped; this will result in an InvalidActorNameException. Instead, watch the terminating actor and create its replacement in response to the Terminated message which will eventually arrive.
+Since stopping an actor is asynchronous, you cannot immediately reuse the name of the child you just stopped; this will result in an `InvalidActorNameException`. Instead, watch the terminating actor and create its replacement in response to the Terminated message which will eventually arrive.
 
 ### PoisonPill
 You can also send an actor the Akka.Actor.PoisonPill message, which will stop the actor when the message is processed. PoisonPill is enqueued as ordinary messages and will be handled after messages that were already queued in the mailbox.
@@ -400,14 +408,15 @@ public class Manager : UntypedActor
         {
             Sender.Tell("service unavailable, shutting down", Self);
         }
-        else if (message is Terminated) {
+        else if (message is Terminated)
+        {
             Context.Stop(Self);
         }
     }
 }
 ```
 
-When `GracefulStop()` returns successfully, the actor’s `PostStop()` hook will have been executed: there exists a happens-before edge between the end of PostStop() and the return of GracefulStop().
+When ```GracefulStop()``` returns successfully, the actor’s ```PostStop()``` hook will have been executed: there exists a happens-before edge between the end of ```PostStop()``` and the return of ```GracefulStop()```.
 
 In the above example a "shutdown" message is sent to the target actor to initiate the process of stopping the actor. You can use PoisonPill for this, but then you have limited possibilities to perform interactions with other actors before stopping the target actor. Simple cleanup tasks can be handled in PostStop.
 


### PR DESCRIPTION
- removed beta designation in recognition of v1.0 release. It's still
  designated in the Persistence and Clustering related articles.
- fixed some documentation relating to the recent move of "I" prefixed
  interfaces
- added cross-links to related articles
- fixed coding style in examples to match rest of code base
- fixed some stilted wording and punctuation to flow better
- added fencing to class designators
- general formatting fixes
