### PR TITLE
Fix for #62

### DIFF
--- a/src/docs/DI Core.md
+++ b/src/docs/DI Core.md
@@ -194,12 +194,3 @@ using (var system = ActorSystem.Create("MySystem"))
     router.Tell(message);
 }
 ```
-
-## Creating Child Actors using DI ##
-When you want to create child actors from within your existing actors using
-Dependency Injection you can use the Actor Content extension just like in
-the following example.
-
-```csharp
-Context.DI().ActorOf<TypedActor>().Tell(message);
-```

--- a/src/docs/Dependency injection.md
+++ b/src/docs/Dependency injection.md
@@ -105,3 +105,16 @@ Techniques for dependency injection and integration with dependency injection
 frameworks are described in more depth in the
 [Using Akka with Dependency Injection](http://letitcrash.com/post/55958814293/akka-dependency-injection)
 guideline.
+
+## Creating Child Actors using DI
+When you want to create child actors from within your existing actors using
+Dependency Injection you can use the Actor Content extension just like in
+the following example.
+
+``csharp
+// For example in the PreStart...
+protected override void PreStart()
+{
+    myWorker = Context.DI().ActorOf<TypedWorker>("childWorker");
+}
+```


### PR DESCRIPTION
The section on creating child actors using DI got inadvertently switched
from Dependency injection to DI Core. This PR reverts that switch.
