### PR TITLE
Removed livereload.js file loading from localhost

### DIFF
--- a/src/partials/head.html
+++ b/src/partials/head.html
@@ -54,9 +54,6 @@
 <!-- Modernizr -->
 <script type="text/javascript" src="/theme_assets/plugins/modernizr.min.js"></script>
 
-<!-- Live reload -->
-<script src="//localhost:35729/livereload.js"></script>
-
 <!--[if lte IE 8]>
   <script src="/theme_assets/plugins/respond.js"></script>
 <![endif]-->


### PR DESCRIPTION
Looks like a leftover file, shouldn't be loading anything from localhost anyway on live site.
