### PR TITLE
Fixed some typos

### DIFF
--- a/src/docs/Documentation guidelines.md
+++ b/src/docs/Documentation guidelines.md
@@ -18,7 +18,7 @@ To contribute to the website's documentation, go to the github project page [get
 
 ## Code
 
-When documenting code, please use the standard .NET convention of [XML documentation comments](https://msdn.microsoft.com/en-us/library/vstudio/b2s063f7(v=vs.110).aspx). This allows the project to use tools like Sandcastle to generate the API documentation for the project. The latest stable API documentation can be found [here](http://api.getakka.net/docs/stable/index.html).
+When documenting code, please use the standard .NET convention of [XML documentation comments](https://msdn.microsoft.com/en-us/library/vstudio/b2s063f7). This allows the project to use tools like Sandcastle to generate the API documentation for the project. The latest stable API documentation can be found [here](http://api.getakka.net/docs/stable/index.html).
 
 Please be mindful to including *useful* comments when documenting a class or method. *Useful* comments means to include full English sentences when summarizing the code and not relying on pre-generated comments from a tool like GhostDoc. Tools like these are great in what they do *if* supplemented with well reasoned grammar.
 
@@ -56,4 +56,4 @@ public abstract class Serializer
 }
 ```
 
-We've all seen the bad examples at one time or another, but rarely do we see the good examples. A nice rule of thumb to remember is to write the comments you would want to see and readwhile perusing the API documentation.
+We've all seen the bad examples at one time or another, but rarely do we see the good examples. A nice rule of thumb to remember is to write the comments you would want to see and read while perusing the API documentation.

--- a/src/docs/IO.md
+++ b/src/docs/IO.md
@@ -4,7 +4,7 @@ title: I/O
 ---
 ## Akka I/O
 
-The I/O extension provides an non-blocking, event driven API that matches the underlaying transports mechanism.
+The I/O extension provides an non-blocking, event driven API that matches the underlying transports mechanism.
 
 Detail of the I/O extension's design can be found in the [Akka JVM documentation](http://doc.akka.io/docs/akka/snapshot/dev/io-layer.html#io-layer).
 
@@ -155,7 +155,7 @@ class EchoConnection : UntypedActor
 ```
 
 ### Akka IO Transport
-The AkkaIOTransport contrib project impliments an Akka Remote transport based on the I/O extension.
+The AkkaIOTransport contrib project implements an Akka Remote transport based on the I/O extension.
 The following shows how to configure Akka Remote to use the IO Transport.
 
 ```hocon


### PR DESCRIPTION
Note that the changed url points to the same place. The url was being misrendered by Markdown and was pointing to an older version of Visual Studio. 
