### PR TITLE
Fix generic parameter brackets in example code.

### DIFF
--- a/src/docs/Working with actors.md
+++ b/src/docs/Working with actors.md
@@ -30,7 +30,7 @@ public class MyActor: ReceiveActor
       log.Info("Received String message: {0}", message);
       Sender.Tell(message);
     });
-    Receive<SomeMessage(message => {...});
+    Receive<SomeMessage>(message => {...});
   }
 }
 ```


### PR DESCRIPTION
Example code was missing a closing bracket on a generic type parameter.
