### PR TITLE
Added a reference to akka remote config file

### DIFF
--- a/src/docs/remoting/index.md
+++ b/src/docs/remoting/index.md
@@ -93,6 +93,8 @@ akka {
 }
 ```
 
+See [Akka Remote Reference Config File](https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka.Remote/Configuration/Remote.conf) for additional information on HOCON settings available in akka remote.
+
 ## Addresses, Transports, Endpoints, and Associations
 In the above section we mentioned that you have to bind a *transport* to an IP address and port, we did in that in HOCON inside the `helios.tcp` section. Why did we have to do any of that?
 


### PR DESCRIPTION
At this point, akka remote config file reference is probably the best place to see what settings are available for akka remote.

Additional comments:
- The content of this document diverges from http://getakka.net/docs/Remoting#using-remoting quite a bit. IMO this has better, more complete content than what is there currently. Are there plans to sync that up (or point the docs to github)?
- The link on getakka.net/docs/Remoting to Edit on github is broken
- Links to other sections of docs (e.g. ../concepts/location-transparency) are broken here.
