### PR TITLE
Syntax for "min-nr-of-members" incorrect

### DIFF
--- a/src/docs/clustering/cluster-configuration.md
+++ b/src/docs/clustering/cluster-configuration.md
@@ -28,7 +28,7 @@ akka {
     cluster {
        seed-nodes = ["akka.tcp://ClusterSystem@127.0.0.1:8081"] # address of seed node
        roles = ["crawler", "logger"] # roles this member is in
-       crawler.min-nr-of-members = 3 # crawler role minimum node count
+       role.["crawler"].min-nr-of-members = 3 # crawler role minimum node count
     }
 }
 ```
@@ -74,7 +74,7 @@ akka {
     cluster {
        seed-nodes = ["akka.tcp://ClusterSystem@127.0.0.1:8081"]
        roles = ["crawlerV1", "crawlerV2"]
-       crawlerV1.min-nr-of-members = 3
+       role.["crawlerV1"].min-nr-of-members = 3
     }
 }
 ```


### PR DESCRIPTION
The "min-nr-of members" setting on role in the cluster area of the HOCON was incorrect.
Changed to:  role.["rolename"].min-nr-of-members = N
