### PR TITLE
Replace apostrophe with web-friendly version.

### DIFF
--- a/src/docs/streams/quickstart.md
+++ b/src/docs/streams/quickstart.md
@@ -31,7 +31,7 @@ using (var materializer = system.Materializer())
 ```
 There are other ways to create a materializer, e.g. from an `ActorContext` when using streams from within Actors. The `Materializer` is a factory for stream execution engines, it is the thing that makes streams run --you don't need to worry about any of the details just now apart from that you need one for calling any of the run methods on a `Source`. 
 
-The nice thing about Akka Streams is that the `Source` is just a description of what you want to run, and like an architect’s blueprint it can be reused, incorporated into a larger design. We may choose to transform the source of integers and write it to a file instead:
+The nice thing about Akka Streams is that the `Source` is just a description of what you want to run, and like an architect's blueprint it can be reused, incorporated into a larger design. We may choose to transform the source of integers and write it to a file instead:
 ```csharp
   var factorials = source.Scan(new BigInteger(1), (acc, next) => acc * next);
   var result =


### PR DESCRIPTION
Noticed this while browsing the docs: 

![pic of issue](https://cloud.githubusercontent.com/assets/2148318/20635888/a3384f44-b331-11e6-9106-503c1ac54fb2.png)

This replaces the apostrophe, which should lead to one less question on the docs (see what I did there? Eh? Eh?)